### PR TITLE
Update example.yaml

### DIFF
--- a/python/ray/autoscaler/aws/example.yaml
+++ b/python/ray/autoscaler/aws/example.yaml
@@ -22,7 +22,7 @@ idle_timeout_minutes: 5
 provider:
     type: aws
     region: us-west-2
-    # availability_zone: us-west-2a
+    availability_zone: us-west-2a
 
 # How Ray will authenticate with newly launched nodes.
 auth:


### PR DESCRIPTION
Fix "ValueError: Missing required config key `availability_zone` of type str" that comes from following autoscaler.rst guide